### PR TITLE
fix gcc compilation error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -360,7 +360,7 @@ add_library (LibOpenHevcWrapper ${libfilenames} ${YASM_OBJECTS})
 if(CRYPTOPP_FOUND)
 target_link_libraries(LibOpenHevcWrapper cryptopp)
 else()
-target_link_libraries(LibOpenHevcWrapper)
+target_link_libraries(LibOpenHevcWrapper m)
 endif()
 
 include_directories(. gpac/modules/openhevc_dec/ platform/x86/)


### PR DESCRIPTION
compilation error in ubuntu 14.04 64 bits :
`/usr/bin/ld: libLibOpenHevcWrapper.a(eval.c.o): undefined reference to symbol «fabs@@GLIBC_2.2.5»
//lib/x86_64-linux-gnu/libm.so.6: error adding symbols: DSO missing from command line`
