### PR TITLE
[ARM][hevc_rext] Resolve linking errors during ARM crosscompilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -296,6 +296,7 @@ list(APPEND libfilenames
     libavutil/arm/asm.S
     libavcodec/arm/fft_init_arm.c
     libavcodec/arm/fft_neon.S
+    libavcodec/arm/fft_vfp.S
     libavcodec/arm/hevcdsp_init_arm.c
     libavcodec/arm/hevcdsp_deblock_neon.S
     libavcodec/arm/hevcdsp_idct_neon.S
@@ -305,10 +306,13 @@ list(APPEND libfilenames
     libavcodec/arm/hpeldsp_arm.S
     libavcodec/arm/hpeldsp_init_arm.c
     libavcodec/arm/hpeldsp_init_neon.c
+    libavcodec/arm/hpeldsp_init_armv6.c
     libavcodec/arm/hpeldsp_neon.S
+    libavcodec/arm/hpeldsp_armv6.S
     libavcodec/arm/int_neon.S
     libavcodec/arm/jrevdct_arm.S
     libavcodec/arm/mdct_neon.S
+    libavcodec/arm/mdct_vfp.S
     libavcodec/arm/rdft_neon.S
     libavcodec/arm/simple_idct_arm.S
     libavcodec/arm/simple_idct_armv6.S

--- a/libavcodec/arm/fft_vfp.S
+++ b/libavcodec/arm/fft_vfp.S
@@ -1,0 +1,530 @@
+/*
+ * Copyright (c) 2013 RISC OS Open Ltd
+ * Author: Ben Avison <bavison@riscosopen.org>
+ *
+ * This file is part of FFmpeg.
+ *
+ * FFmpeg is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * FFmpeg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with FFmpeg; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#include "libavutil/arm/asm.S"
+
+@ The fftx_internal_vfp versions of the functions obey a modified AAPCS:
+@ VFP is in RunFast mode, vector length 4, stride 1 thoroughout, and
+@ all single-precision VFP registers may be corrupted on exit. The a2
+@ register may not be clobbered in these functions, as it holds the
+@ stored original FPSCR.
+
+function ff_fft_calc_vfp, export=1
+        ldr     ip, [a1, #0]    @ nbits
+        mov     a1, a2
+        movrel  a2, (fft_tab_vfp - 8)
+        ldr     pc, [a2, ip, lsl #2]
+endfunc
+const   fft_tab_vfp
+        .word   fft4_vfp
+        .word   fft8_vfp
+        .word   X(ff_fft16_vfp)     @ this one alone is exported
+        .word   fft32_vfp
+        .word   fft64_vfp
+        .word   fft128_vfp
+        .word   fft256_vfp
+        .word   fft512_vfp
+        .word   fft1024_vfp
+        .word   fft2048_vfp
+        .word   fft4096_vfp
+        .word   fft8192_vfp
+        .word   fft16384_vfp
+        .word   fft32768_vfp
+        .word   fft65536_vfp
+endconst
+
+function fft4_vfp
+        vldr    d0, [a1, #0*2*4]   @ s0,s1   = z[0]
+        vldr    d4, [a1, #1*2*4]   @ s8,s9   = z[1]
+        vldr    d1, [a1, #2*2*4]   @ s2,s3   = z[2]
+        vldr    d5, [a1, #3*2*4]   @ s10,s11 = z[3]
+        @ stall
+        vadd.f  s12, s0, s8        @ i0
+        vadd.f  s13, s1, s9        @ i1
+        vadd.f  s14, s2, s10       @ i2
+        vadd.f  s15, s3, s11       @ i3
+        vsub.f  s8, s0, s8         @ i4
+        vsub.f  s9, s1, s9         @ i5
+        vsub.f  s10, s2, s10       @ i6
+        vsub.f  s11, s3, s11       @ i7
+        @ stall
+        @ stall
+        vadd.f  s0, s12, s14       @ z[0].re
+        vsub.f  s4, s12, s14       @ z[2].re
+        vadd.f  s1, s13, s15       @ z[0].im
+        vsub.f  s5, s13, s15       @ z[2].im
+        vadd.f  s7, s9, s10        @ z[3].im
+        vsub.f  s3, s9, s10        @ z[1].im
+        vadd.f  s2, s8, s11        @ z[1].re
+        vsub.f  s6, s8, s11        @ z[3].re
+        @ stall
+        @ stall
+        vstr    d0, [a1, #0*2*4]
+        vstr    d2, [a1, #2*2*4]
+        @ stall
+        @ stall
+        vstr    d1, [a1, #1*2*4]
+        vstr    d3, [a1, #3*2*4]
+
+        bx      lr
+endfunc
+
+.macro macro_fft8_head
+        @ FFT4
+        vldr    d4, [a1, #0 * 2*4]
+        vldr    d6, [a1, #1 * 2*4]
+        vldr    d5, [a1, #2 * 2*4]
+        vldr    d7, [a1, #3 * 2*4]
+            @ BF
+            vldr    d12, [a1, #4 * 2*4]
+        vadd.f  s16, s8, s12    @ vector op
+            vldr    d14, [a1, #5 * 2*4]
+            vldr    d13, [a1, #6 * 2*4]
+            vldr    d15, [a1, #7 * 2*4]
+        vsub.f  s20, s8, s12    @ vector op
+        vadd.f  s0, s16, s18
+        vsub.f  s2, s16, s18
+        vadd.f  s1, s17, s19
+        vsub.f  s3, s17, s19
+        vadd.f  s7, s21, s22
+        vsub.f  s5, s21, s22
+        vadd.f  s4, s20, s23
+        vsub.f  s6, s20, s23
+            vsub.f  s20, s24, s28   @ vector op
+        vstr    d0, [a1, #0 * 2*4]  @ transfer s0-s7 to s24-s31 via memory
+        vstr    d1, [a1, #1 * 2*4]
+        vldr    s0, cos1pi4
+            vadd.f  s16, s24, s28   @ vector op
+        vstr    d2, [a1, #2 * 2*4]
+        vstr    d3, [a1, #3 * 2*4]
+        vldr    d12, [a1, #0 * 2*4]
+            @ TRANSFORM
+            vmul.f  s20, s20, s0    @ vector x scalar op
+        vldr    d13, [a1, #1 * 2*4]
+        vldr    d14, [a1, #2 * 2*4]
+        vldr    d15, [a1, #3 * 2*4]
+        @ BUTTERFLIES
+        vadd.f  s0, s18, s16
+        vadd.f  s1, s17, s19
+        vsub.f  s2, s17, s19
+        vsub.f  s3, s18, s16
+            vadd.f  s4, s21, s20
+            vsub.f  s5, s21, s20
+            vadd.f  s6, s22, s23
+            vsub.f  s7, s22, s23
+        vadd.f  s8, s0, s24         @ vector op
+        vstr    d0, [a1, #0 * 2*4]  @ transfer s0-s3 to s12-s15 via memory
+        vstr    d1, [a1, #1 * 2*4]
+        vldr    d6, [a1, #0 * 2*4]
+        vldr    d7, [a1, #1 * 2*4]
+            vadd.f  s1, s5, s6
+            vadd.f  s0, s7, s4
+            vsub.f  s2, s5, s6
+            vsub.f  s3, s7, s4
+        vsub.f  s12, s24, s12       @ vector op
+            vsub.f  s5, s29, s1
+            vsub.f  s4, s28, s0
+            vsub.f  s6, s30, s2
+            vsub.f  s7, s31, s3
+            vadd.f  s16, s0, s28    @ vector op
+        vstr    d6, [a1, #4 * 2*4]
+        vstr    d7, [a1, #6 * 2*4]
+        vstr    d4, [a1, #0 * 2*4]
+        vstr    d5, [a1, #2 * 2*4]
+             vstr    d2, [a1, #5 * 2*4]
+             vstr    d3, [a1, #7 * 2*4]
+.endm
+
+.macro macro_fft8_tail
+             vstr    d8, [a1, #1 * 2*4]
+             vstr    d9, [a1, #3 * 2*4]
+.endm
+
+function .Lfft8_internal_vfp
+        macro_fft8_head
+        macro_fft8_tail
+        bx      lr
+endfunc
+
+function fft8_vfp
+        ldr     a3, =0x03030000     @ RunFast mode, vector length 4, stride 1
+        fmrx    a2, FPSCR
+        fmxr    FPSCR, a3
+        vpush   {s16-s31}
+        mov     ip, lr
+        bl      .Lfft8_internal_vfp
+        vpop    {s16-s31}
+        fmxr    FPSCR, a2
+        bx      ip
+endfunc
+
+.align 3
+cos1pi4:    @ cos(1*pi/4) = sqrt(2)
+        .float  0.707106769084930419921875
+cos1pi8:    @ cos(1*pi/8) = sqrt(2+sqrt(2))/2
+        .float  0.92387950420379638671875
+cos3pi8:    @ cos(2*pi/8) = sqrt(2-sqrt(2))/2
+        .float  0.3826834261417388916015625
+
+function .Lfft16_internal_vfp
+        macro_fft8_head
+        @ FFT4(z+8)
+        vldr    d10, [a1, #8 * 2*4]
+        vldr    d12, [a1, #9 * 2*4]
+        vldr    d11, [a1, #10 * 2*4]
+        vldr    d13, [a1, #11 * 2*4]
+        macro_fft8_tail
+        vadd.f  s16, s20, s24   @ vector op
+            @ FFT4(z+12)
+            vldr    d4, [a1, #12 * 2*4]
+            vldr    d6, [a1, #13 * 2*4]
+            vldr    d5, [a1, #14 * 2*4]
+        vsub.f  s20, s20, s24   @ vector op
+            vldr    d7, [a1, #15 * 2*4]
+        vadd.f  s0, s16, s18
+        vsub.f  s4, s16, s18
+        vadd.f  s1, s17, s19
+        vsub.f  s5, s17, s19
+        vadd.f  s7, s21, s22
+        vsub.f  s3, s21, s22
+        vadd.f  s2, s20, s23
+        vsub.f  s6, s20, s23
+            vadd.f  s16, s8, s12    @ vector op
+        vstr    d0, [a1, #8 * 2*4]
+        vstr    d2, [a1, #10 * 2*4]
+        vstr    d1, [a1, #9 * 2*4]
+            vsub.f  s20, s8, s12
+        vstr    d3, [a1, #11 * 2*4]
+        @ TRANSFORM(z[2],z[6],z[10],z[14],cos1pi4,cos1pi4)
+        vldr    d12, [a1, #10 * 2*4]
+            vadd.f  s0, s16, s18
+            vadd.f  s1, s17, s19
+            vsub.f  s6, s16, s18
+            vsub.f  s7, s17, s19
+            vsub.f  s3, s21, s22
+            vadd.f  s2, s20, s23
+            vadd.f  s5, s21, s22
+            vsub.f  s4, s20, s23
+            vstr    d0, [a1, #12 * 2*4]
+        vmov    s0, s6
+          @ TRANSFORM(z[1],z[5],z[9],z[13],cos1pi8,cos3pi8)
+          vldr    d6, [a1, #9 * 2*4]
+            vstr    d1, [a1, #13 * 2*4]
+        vldr    d1, cos1pi4 @ s2 = cos1pi4, s3 = cos1pi8
+            vstr    d2, [a1, #15 * 2*4]
+          vldr    d7, [a1, #13 * 2*4]
+        vadd.f  s4, s25, s24
+        vsub.f  s5, s25, s24
+        vsub.f  s6, s0, s7
+        vadd.f  s7, s0, s7
+          vmul.f  s20, s12, s3  @ vector op
+            @ TRANSFORM(z[3],z[7],z[11],z[15],cos3pi8,cos1pi8)
+            vldr    d4, [a1, #11 * 2*4]
+            vldr    d5, [a1, #15 * 2*4]
+            vldr    s1, cos3pi8
+        vmul.f  s24, s4, s2     @ vector * scalar op
+          vmul.f  s28, s12, s1  @ vector * scalar op
+            vmul.f  s12, s8, s1 @ vector * scalar op
+          vadd.f  s4, s20, s29
+          vsub.f  s5, s21, s28
+          vsub.f  s6, s22, s31
+          vadd.f  s7, s23, s30
+            vmul.f  s8, s8, s3  @ vector * scalar op
+          vldr    d8, [a1, #1 * 2*4]
+          vldr    d9, [a1, #5 * 2*4]
+            vldr    d10, [a1, #3 * 2*4]
+            vldr    d11, [a1, #7 * 2*4]
+        vldr    d14, [a1, #2 * 2*4]
+          vadd.f  s0, s6, s4
+          vadd.f  s1, s5, s7
+          vsub.f  s2, s5, s7
+          vsub.f  s3, s6, s4
+            vadd.f  s4, s12, s9
+            vsub.f  s5, s13, s8
+            vsub.f  s6, s14, s11
+            vadd.f  s7, s15, s10
+          vadd.f  s12, s0, s16  @ vector op
+          vstr    d0, [a1, #1 * 2*4]
+          vstr    d1, [a1, #5 * 2*4]
+          vldr    d4, [a1, #1 * 2*4]
+          vldr    d5, [a1, #5 * 2*4]
+            vadd.f  s0, s6, s4
+            vadd.f  s1, s5, s7
+            vsub.f  s2, s5, s7
+            vsub.f  s3, s6, s4
+          vsub.f  s8, s16, s8   @ vector op
+          vstr    d6, [a1, #1 * 2*4]
+          vstr    d7, [a1, #5 * 2*4]
+        vldr    d15, [a1, #6 * 2*4]
+            vsub.f  s4, s20, s0
+            vsub.f  s5, s21, s1
+            vsub.f  s6, s22, s2
+            vsub.f  s7, s23, s3
+            vadd.f  s20, s0, s20    @ vector op
+          vstr    d4, [a1, #9 * 2*4]
+              @ TRANSFORM_ZERO(z[0],z[4],z[8],z[12])
+              vldr    d6, [a1, #8 * 2*4]
+          vstr    d5, [a1, #13 * 2*4]
+              vldr    d7, [a1, #12 * 2*4]
+          vstr    d2, [a1, #11 * 2*4]
+              vldr    d8, [a1, #0 * 2*4]
+          vstr    d3, [a1, #15 * 2*4]
+              vldr    d9, [a1, #4 * 2*4]
+        vadd.f  s0, s26, s24
+        vadd.f  s1, s25, s27
+        vsub.f  s2, s25, s27
+        vsub.f  s3, s26, s24
+              vadd.f  s4, s14, s12
+              vadd.f  s5, s13, s15
+              vsub.f  s6, s13, s15
+              vsub.f  s7, s14, s12
+        vadd.f  s8, s0, s28 @ vector op
+        vstr    d0, [a1, #3 * 2*4]
+        vstr    d1, [a1, #7 * 2*4]
+        vldr    d6, [a1, #3 * 2*4]
+        vldr    d7, [a1, #7 * 2*4]
+              vsub.f  s0, s16, s4
+              vsub.f  s1, s17, s5
+              vsub.f  s2, s18, s6
+              vsub.f  s3, s19, s7
+        vsub.f  s12, s28, s12       @ vector op
+              vadd.f  s16, s4, s16  @ vector op
+            vstr    d10, [a1, #3 * 2*4]
+            vstr    d11, [a1, #7 * 2*4]
+        vstr    d4, [a1, #2 * 2*4]
+        vstr    d5, [a1, #6 * 2*4]
+              vstr    d0, [a1, #8 * 2*4]
+              vstr    d1, [a1, #12 * 2*4]
+        vstr    d6, [a1, #10 * 2*4]
+        vstr    d7, [a1, #14 * 2*4]
+              vstr    d8, [a1, #0 * 2*4]
+              vstr    d9, [a1, #4 * 2*4]
+
+        bx      lr
+endfunc
+
+function ff_fft16_vfp, export=1
+        ldr     a3, =0x03030000     @ RunFast mode, vector length 4, stride 1
+        fmrx    a2, FPSCR
+        fmxr    FPSCR, a3
+        vpush   {s16-s31}
+        mov     ip, lr
+        bl      .Lfft16_internal_vfp
+        vpop    {s16-s31}
+        fmxr    FPSCR, a2
+        bx      ip
+endfunc
+
+.macro pass n, z0, z1, z2, z3
+        add     v6, v5, #4*2*\n
+        @ TRANSFORM_ZERO(z[0],z[o1],z[o2],z[o3])
+            @ TRANSFORM(z[1],z[o1+1],z[o2+1],z[o3+1],wre[1],wim[-1])
+                @ TRANSFORM(z[0],z[o1],z[o2],z[o3],wre[0],wim[0])
+                    @ TRANSFORM(z[1],z[o1+1],z[o2+1],z[o3+1],wre[1],wim[-1])
+            vldr    d8, [\z2, #8*(o2+1)]        @ s16,s17
+            vldmdb  v6!, {s2}
+            vldr    d9, [\z3, #8*(o3+1)]        @ s18,s19
+            vldmia  v5!, {s0,s1}                @ s0 is unused
+        vldr    s7, [\z2, #8*o2]            @ t1
+            vmul.f  s20, s16, s2                @ vector * scalar
+        vldr    s0, [\z3, #8*o3]            @ t5
+        vldr    s6, [\z2, #8*o2+4]          @ t2
+        vldr    s3, [\z3, #8*o3+4]          @ t6
+            vmul.f  s16, s16, s1                @ vector * scalar
+        ldr     a4, =\n-1
+1:      add     \z0, \z0, #8*2
+ .if \n*4*2 >= 512
+        add     \z1, \z1, #8*2
+ .endif
+ .if \n*4*2 >= 256
+        add     \z2, \z2, #8*2
+ .endif
+ .if \n*4*2 >= 512
+        add     \z3, \z3, #8*2
+ .endif
+        @ up to 2 stalls (VFP vector issuing / waiting for s0)
+        @ depending upon whether this is the first iteration and
+        @ how many add instructions are inserted above
+        vadd.f  s4, s0, s7                  @ t5
+        vadd.f  s5, s6, s3                  @ t6
+        vsub.f  s6, s6, s3                  @ t4
+        vsub.f  s7, s0, s7                  @ t3
+        vldr    d6, [\z0, #8*0-8*2]         @ s12,s13
+            vadd.f  s0, s16, s21                @ t1
+        vldr    d7, [\z1, #8*o1-8*2]        @ s14,s15
+            vsub.f  s1, s18, s23                @ t5
+        vadd.f  s8, s4, s12                 @ vector + vector
+        @ stall (VFP vector issuing)
+        @ stall (VFP vector issuing)
+        @ stall (VFP vector issuing)
+        vsub.f  s4, s12, s4
+        vsub.f  s5, s13, s5
+        vsub.f  s6, s14, s6
+        vsub.f  s7, s15, s7
+            vsub.f  s2, s17, s20                @ t2
+            vadd.f  s3, s19, s22                @ t6
+        vstr    d4, [\z0, #8*0-8*2]         @ s8,s9
+        vstr    d5, [\z1, #8*o1-8*2]        @ s10,s11
+        @ stall (waiting for s5)
+        vstr    d2, [\z2, #8*o2-8*2]        @ s4,s5
+            vadd.f  s4, s1, s0                  @ t5
+        vstr    d3, [\z3, #8*o3-8*2]        @ s6,s7
+            vsub.f  s7, s1, s0                  @ t3
+            vadd.f  s5, s2, s3                  @ t6
+            vsub.f  s6, s2, s3                  @ t4
+            vldr    d6, [\z0, #8*1-8*2]         @ s12,s13
+            vldr    d7, [\z1, #8*(o1+1)-8*2]    @ s14,s15
+                vldr    d4, [\z2, #8*o2]            @ s8,s9
+                vldmdb  v6!, {s2,s3}
+                vldr    d5, [\z3, #8*o3]            @ s10,s11
+            vadd.f  s20, s4, s12                @ vector + vector
+                vldmia  v5!, {s0,s1}
+                    vldr    d8, [\z2, #8*(o2+1)]        @ s16,s17
+            @ stall (VFP vector issuing)
+            vsub.f  s4, s12, s4
+            vsub.f  s5, s13, s5
+            vsub.f  s6, s14, s6
+            vsub.f  s7, s15, s7
+                vmul.f  s12, s8, s3                 @ vector * scalar
+            vstr    d10, [\z0, #8*1-8*2]        @ s20,s21
+                    vldr    d9, [\z3, #8*(o3+1)]        @ s18,s19
+            vstr    d11, [\z1, #8*(o1+1)-8*2]   @ s22,s23
+                vmul.f  s8, s8, s0                  @ vector * scalar
+            vstr    d2, [\z2, #8*(o2+1)-8*2]    @ s4,s5
+            @ stall (waiting for s7)
+            vstr    d3, [\z3, #8*(o3+1)-8*2]    @ s6,s7
+                    vmul.f  s20, s16, s2                @ vector * scalar
+                @ stall (VFP vector issuing)
+                @ stall (VFP vector issuing)
+                @ stall (VFP vector issuing)
+                vadd.f  s7, s8, s13                 @ t1
+                vsub.f  s6, s9, s12                 @ t2
+                vsub.f  s0, s10, s15                @ t5
+                vadd.f  s3, s11, s14                @ t6
+                    vmul.f  s16, s16, s1                @ vector * scalar
+        subs    a4, a4, #1
+        bne     1b
+        @ What remains is identical to the first two indentations of
+        @ the above, but without the increment of z
+        vadd.f  s4, s0, s7                  @ t5
+        vadd.f  s5, s6, s3                  @ t6
+        vsub.f  s6, s6, s3                  @ t4
+        vsub.f  s7, s0, s7                  @ t3
+        vldr    d6, [\z0, #8*0]             @ s12,s13
+            vadd.f  s0, s16, s21                @ t1
+        vldr    d7, [\z1, #8*o1]            @ s14,s15
+            vsub.f  s1, s18, s23                @ t5
+        vadd.f  s8, s4, s12                 @ vector + vector
+        vsub.f  s4, s12, s4
+        vsub.f  s5, s13, s5
+        vsub.f  s6, s14, s6
+        vsub.f  s7, s15, s7
+            vsub.f  s2, s17, s20                @ t2
+            vadd.f  s3, s19, s22                @ t6
+        vstr    d4, [\z0, #8*0]             @ s8,s9
+        vstr    d5, [\z1, #8*o1]            @ s10,s11
+        vstr    d2, [\z2, #8*o2]            @ s4,s5
+            vadd.f  s4, s1, s0                  @ t5
+        vstr    d3, [\z3, #8*o3]            @ s6,s7
+            vsub.f  s7, s1, s0                  @ t3
+            vadd.f  s5, s2, s3                  @ t6
+            vsub.f  s6, s2, s3                  @ t4
+            vldr    d6, [\z0, #8*1]             @ s12,s13
+            vldr    d7, [\z1, #8*(o1+1)]        @ s14,s15
+            vadd.f  s20, s4, s12                @ vector + vector
+            vsub.f  s4, s12, s4
+            vsub.f  s5, s13, s5
+            vsub.f  s6, s14, s6
+            vsub.f  s7, s15, s7
+            vstr    d10, [\z0, #8*1]            @ s20,s21
+            vstr    d11, [\z1, #8*(o1+1)]       @ s22,s23
+            vstr    d2, [\z2, #8*(o2+1)]        @ s4,s5
+            vstr    d3, [\z3, #8*(o3+1)]        @ s6,s7
+.endm
+
+.macro  def_fft n, n2, n4
+function .Lfft\n\()_internal_vfp
+ .if \n >= 512
+        push    {v1-v6,lr}
+ .elseif \n >= 256
+        push    {v1-v2,v5-v6,lr}
+ .else
+        push    {v1,v5-v6,lr}
+ .endif
+        mov     v1, a1
+        bl      .Lfft\n2\()_internal_vfp
+        add     a1, v1, #8*(\n/4)*2
+        bl      .Lfft\n4\()_internal_vfp
+        movrelx v5, X(ff_cos_\n), a1
+        add     a1, v1, #8*(\n/4)*3
+        bl      .Lfft\n4\()_internal_vfp
+ .if \n >= 512
+  .set o1, 0*(\n/4/2)
+  .set o2, 0*(\n/4/2)
+  .set o3, 0*(\n/4/2)
+        add     v2, v1, #8*2*(\n/4/2)
+        add     v3, v1, #8*4*(\n/4/2)
+        add     v4, v1, #8*6*(\n/4/2)
+        pass    (\n/4/2), v1, v2, v3, v4
+        pop     {v1-v6,pc}
+ .elseif \n >= 256
+  .set o1, 2*(\n/4/2)
+  .set o2, 0*(\n/4/2)
+  .set o3, 2*(\n/4/2)
+        add     v2, v1, #8*4*(\n/4/2)
+        pass    (\n/4/2), v1, v1, v2, v2
+        pop     {v1-v2,v5-v6,pc}
+ .else
+  .set o1, 2*(\n/4/2)
+  .set o2, 4*(\n/4/2)
+  .set o3, 6*(\n/4/2)
+        pass    (\n/4/2), v1, v1, v1, v1
+        pop     {v1,v5-v6,pc}
+ .endif
+endfunc
+
+function fft\n\()_vfp
+        ldr     a3, =0x03030000 /* RunFast mode, vector length 4, stride 1 */
+        fmrx    a2, FPSCR
+        fmxr    FPSCR, a3
+        vpush   {s16-s31}
+        mov     ip, lr
+        bl      .Lfft\n\()_internal_vfp
+        vpop    {s16-s31}
+        fmxr    FPSCR, a2
+        bx      ip
+endfunc
+
+.ltorg
+.endm
+
+        def_fft    32,    16,     8
+        def_fft    64,    32,    16
+        def_fft   128,    64,    32
+        def_fft   256,   128,    64
+        def_fft   512,   256,   128
+        def_fft  1024,   512,   256
+        def_fft  2048,  1024,   512
+        def_fft  4096,  2048,  1024
+        def_fft  8192,  4096,  2048
+        def_fft 16384,  8192,  4096
+        def_fft 32768, 16384,  8192
+        def_fft 65536, 32768, 16384

--- a/libavcodec/arm/hpeldsp_armv6.S
+++ b/libavcodec/arm/hpeldsp_armv6.S
@@ -1,0 +1,261 @@
+/*
+ * Copyright (c) 2009 Mans Rullgard <mans@mansr.com>
+ *
+ * This file is part of FFmpeg.
+ *
+ * FFmpeg is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * FFmpeg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with FFmpeg; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#include "libavutil/arm/asm.S"
+
+.macro  call_2x_pixels  type, subp
+function ff_\type\()_pixels16\subp\()_armv6, export=1
+        push            {r0-r3, lr}
+        bl              X(ff_\type\()_pixels8\subp\()_armv6)
+        pop             {r0-r3, lr}
+        add             r0,  r0,  #8
+        add             r1,  r1,  #8
+        b               X(ff_\type\()_pixels8\subp\()_armv6)
+endfunc
+.endm
+
+call_2x_pixels          avg
+call_2x_pixels          put, _x2
+call_2x_pixels          put, _y2
+call_2x_pixels          put, _x2_no_rnd
+call_2x_pixels          put, _y2_no_rnd
+
+function ff_put_pixels16_armv6, export=1
+        push            {r4-r11}
+1:
+        ldr             r5,  [r1, #4]
+        ldr             r6,  [r1, #8]
+        ldr             r7,  [r1, #12]
+        ldr_post        r4,  r1,  r2
+        strd            r6,  r7,  [r0, #8]
+        ldr             r9,  [r1, #4]
+        strd_post       r4,  r5,  r0,  r2
+        ldr             r10, [r1, #8]
+        ldr             r11, [r1, #12]
+        ldr_post        r8,  r1,  r2
+        strd            r10, r11, [r0, #8]
+        subs            r3,  r3,  #2
+        strd_post       r8,  r9,  r0,  r2
+        bne             1b
+
+        pop             {r4-r11}
+        bx              lr
+endfunc
+
+function ff_put_pixels8_armv6, export=1
+        push            {r4-r7}
+1:
+        ldr             r5,  [r1, #4]
+        ldr_post        r4,  r1,  r2
+        ldr             r7,  [r1, #4]
+        strd_post       r4,  r5,  r0,  r2
+        ldr_post        r6,  r1,  r2
+        subs            r3,  r3,  #2
+        strd_post       r6,  r7,  r0,  r2
+        bne             1b
+
+        pop             {r4-r7}
+        bx              lr
+endfunc
+
+function ff_put_pixels8_x2_armv6, export=1
+        push            {r4-r11, lr}
+        mov             r12, #1
+        orr             r12, r12, r12, lsl #8
+        orr             r12, r12, r12, lsl #16
+1:
+        ldr             r4,  [r1]
+        subs            r3,  r3,  #2
+        ldr             r5,  [r1, #4]
+        ldr             r7,  [r1, #5]
+        lsr             r6,  r4,  #8
+        ldr_pre         r8,  r1,  r2
+        orr             r6,  r6,  r5,  lsl #24
+        ldr             r9,  [r1, #4]
+        ldr             r11, [r1, #5]
+        lsr             r10, r8,  #8
+        add             r1,  r1,  r2
+        orr             r10, r10, r9,  lsl #24
+        eor             r14, r4,  r6
+        uhadd8          r4,  r4,  r6
+        eor             r6,  r5,  r7
+        uhadd8          r5,  r5,  r7
+        and             r14, r14, r12
+        and             r6,  r6,  r12
+        uadd8           r4,  r4,  r14
+        eor             r14, r8,  r10
+        uadd8           r5,  r5,  r6
+        eor             r6,  r9,  r11
+        uhadd8          r8,  r8,  r10
+        and             r14, r14, r12
+        uhadd8          r9,  r9,  r11
+        and             r6,  r6,  r12
+        uadd8           r8,  r8,  r14
+        strd_post       r4,  r5,  r0,  r2
+        uadd8           r9,  r9,  r6
+        strd_post       r8,  r9,  r0,  r2
+        bne             1b
+
+        pop             {r4-r11, pc}
+endfunc
+
+function ff_put_pixels8_y2_armv6, export=1
+        push            {r4-r11}
+        mov             r12, #1
+        orr             r12, r12, r12, lsl #8
+        orr             r12, r12, r12, lsl #16
+        ldr             r4,  [r1]
+        ldr             r5,  [r1, #4]
+        ldr_pre         r6,  r1,  r2
+        ldr             r7,  [r1, #4]
+1:
+        subs            r3,  r3,  #2
+        uhadd8          r8,  r4,  r6
+        eor             r10, r4,  r6
+        uhadd8          r9,  r5,  r7
+        eor             r11, r5,  r7
+        and             r10, r10, r12
+        ldr_pre         r4,  r1,  r2
+        uadd8           r8,  r8,  r10
+        and             r11, r11, r12
+        uadd8           r9,  r9,  r11
+        ldr             r5,  [r1, #4]
+        uhadd8          r10, r4,  r6
+        eor             r6,  r4,  r6
+        uhadd8          r11, r5,  r7
+        and             r6,  r6,  r12
+        eor             r7,  r5,  r7
+        uadd8           r10, r10, r6
+        and             r7,  r7,  r12
+        ldrc_pre        ne,  r6,  r1,  r2
+        uadd8           r11, r11, r7
+        strd_post       r8,  r9,  r0,  r2
+        it              ne
+        ldrne           r7,  [r1, #4]
+        strd_post       r10, r11, r0,  r2
+        bne             1b
+
+        pop             {r4-r11}
+        bx              lr
+endfunc
+
+function ff_put_pixels8_x2_no_rnd_armv6, export=1
+        push            {r4-r9, lr}
+1:
+        subs            r3,  r3,  #2
+        ldr             r4,  [r1]
+        ldr             r5,  [r1, #4]
+        ldr             r7,  [r1, #5]
+        ldr_pre         r8,  r1,  r2
+        ldr             r9,  [r1, #4]
+        ldr             r14, [r1, #5]
+        add             r1,  r1,  r2
+        lsr             r6,  r4,  #8
+        orr             r6,  r6,  r5,  lsl #24
+        lsr             r12, r8,  #8
+        orr             r12, r12, r9,  lsl #24
+        uhadd8          r4,  r4,  r6
+        uhadd8          r5,  r5,  r7
+        uhadd8          r8,  r8,  r12
+        uhadd8          r9,  r9,  r14
+        stm             r0,  {r4,r5}
+        add             r0,  r0,  r2
+        stm             r0,  {r8,r9}
+        add             r0,  r0,  r2
+        bne             1b
+
+        pop             {r4-r9, pc}
+endfunc
+
+function ff_put_pixels8_y2_no_rnd_armv6, export=1
+        push            {r4-r9, lr}
+        ldr             r4,  [r1]
+        ldr             r5,  [r1, #4]
+        ldr_pre         r6,  r1,  r2
+        ldr             r7,  [r1, #4]
+1:
+        subs            r3,  r3,  #2
+        uhadd8          r8,  r4,  r6
+        ldr_pre         r4,  r1,  r2
+        uhadd8          r9,  r5,  r7
+        ldr             r5,  [r1, #4]
+        uhadd8          r12, r4,  r6
+        ldrc_pre        ne,  r6,  r1,  r2
+        uhadd8          r14, r5,  r7
+        it              ne
+        ldrne           r7,  [r1, #4]
+        stm             r0,  {r8,r9}
+        add             r0,  r0,  r2
+        stm             r0,  {r12,r14}
+        add             r0,  r0,  r2
+        bne             1b
+
+        pop             {r4-r9, pc}
+endfunc
+
+function ff_avg_pixels8_armv6, export=1
+        pld             [r1, r2]
+        push            {r4-r10, lr}
+        mov             lr,  #1
+        orr             lr,  lr,  lr,  lsl #8
+        orr             lr,  lr,  lr,  lsl #16
+        ldrd            r4,  r5,  [r0]
+        ldr             r10, [r1, #4]
+        ldr_post        r9,  r1,  r2
+        subs            r3,  r3,  #2
+1:
+        pld             [r1, r2]
+        eor             r8,  r4,  r9
+        uhadd8          r4,  r4,  r9
+        eor             r12, r5,  r10
+        ldrd_reg        r6,  r7,  r0,  r2
+        uhadd8          r5,  r5,  r10
+        and             r8,  r8,  lr
+        ldr             r10, [r1, #4]
+        and             r12, r12, lr
+        uadd8           r4,  r4,  r8
+        ldr_post        r9,  r1,  r2
+        eor             r8,  r6,  r9
+        uadd8           r5,  r5,  r12
+        pld             [r1, r2,  lsl #1]
+        eor             r12, r7,  r10
+        uhadd8          r6,  r6,  r9
+        strd_post       r4,  r5,  r0,  r2
+        uhadd8          r7,  r7,  r10
+        beq             2f
+        and             r8,  r8,  lr
+        ldrd_reg        r4,  r5,  r0,  r2
+        uadd8           r6,  r6,  r8
+        ldr             r10, [r1, #4]
+        and             r12, r12, lr
+        subs            r3,  r3,  #2
+        uadd8           r7,  r7,  r12
+        ldr_post        r9,  r1,  r2
+        strd_post       r6,  r7,  r0,  r2
+        b               1b
+2:
+        and             r8,  r8,  lr
+        and             r12, r12, lr
+        uadd8           r6,  r6,  r8
+        uadd8           r7,  r7,  r12
+        strd_post       r6,  r7,  r0,  r2
+
+        pop             {r4-r10, pc}
+endfunc

--- a/libavcodec/arm/hpeldsp_init_armv6.c
+++ b/libavcodec/arm/hpeldsp_init_armv6.c
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2009 Mans Rullgard <mans@mansr.com>
+ *
+ * This file is part of FFmpeg.
+ *
+ * FFmpeg is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * FFmpeg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with FFmpeg; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "libavutil/attributes.h"
+#include "hpeldsp_arm.h"
+
+void ff_put_pixels16_armv6(uint8_t *, const uint8_t *, ptrdiff_t, int);
+void ff_put_pixels16_x2_armv6(uint8_t *, const uint8_t *, ptrdiff_t, int);
+void ff_put_pixels16_y2_armv6(uint8_t *, const uint8_t *, ptrdiff_t, int);
+
+void ff_put_pixels16_x2_no_rnd_armv6(uint8_t *, const uint8_t *, ptrdiff_t, int);
+void ff_put_pixels16_y2_no_rnd_armv6(uint8_t *, const uint8_t *, ptrdiff_t, int);
+
+void ff_avg_pixels16_armv6(uint8_t *, const uint8_t *, ptrdiff_t, int);
+
+void ff_put_pixels8_armv6(uint8_t *, const uint8_t *, ptrdiff_t, int);
+void ff_put_pixels8_x2_armv6(uint8_t *, const uint8_t *, ptrdiff_t, int);
+void ff_put_pixels8_y2_armv6(uint8_t *, const uint8_t *, ptrdiff_t, int);
+
+void ff_put_pixels8_x2_no_rnd_armv6(uint8_t *, const uint8_t *, ptrdiff_t, int);
+void ff_put_pixels8_y2_no_rnd_armv6(uint8_t *, const uint8_t *, ptrdiff_t, int);
+
+void ff_avg_pixels8_armv6(uint8_t *, const uint8_t *, ptrdiff_t, int);
+
+av_cold void ff_hpeldsp_init_armv6(HpelDSPContext *c, int flags)
+{
+    c->put_pixels_tab[0][0] = ff_put_pixels16_armv6;
+    c->put_pixels_tab[0][1] = ff_put_pixels16_x2_armv6;
+    c->put_pixels_tab[0][2] = ff_put_pixels16_y2_armv6;
+/*     c->put_pixels_tab[0][3] = ff_put_pixels16_xy2_armv6; */
+    c->put_pixels_tab[1][0] = ff_put_pixels8_armv6;
+    c->put_pixels_tab[1][1] = ff_put_pixels8_x2_armv6;
+    c->put_pixels_tab[1][2] = ff_put_pixels8_y2_armv6;
+/*     c->put_pixels_tab[1][3] = ff_put_pixels8_xy2_armv6; */
+
+    c->put_no_rnd_pixels_tab[0][0] = ff_put_pixels16_armv6;
+    c->put_no_rnd_pixels_tab[0][1] = ff_put_pixels16_x2_no_rnd_armv6;
+    c->put_no_rnd_pixels_tab[0][2] = ff_put_pixels16_y2_no_rnd_armv6;
+/*     c->put_no_rnd_pixels_tab[0][3] = ff_put_pixels16_xy2_no_rnd_armv6; */
+    c->put_no_rnd_pixels_tab[1][0] = ff_put_pixels8_armv6;
+    c->put_no_rnd_pixels_tab[1][1] = ff_put_pixels8_x2_no_rnd_armv6;
+    c->put_no_rnd_pixels_tab[1][2] = ff_put_pixels8_y2_no_rnd_armv6;
+/*     c->put_no_rnd_pixels_tab[1][3] = ff_put_pixels8_xy2_no_rnd_armv6; */
+
+    c->avg_pixels_tab[0][0] = ff_avg_pixels16_armv6;
+    c->avg_pixels_tab[1][0] = ff_avg_pixels8_armv6;
+}

--- a/libavcodec/arm/mdct_vfp.S
+++ b/libavcodec/arm/mdct_vfp.S
@@ -1,0 +1,347 @@
+/*
+ * Copyright (c) 2013 RISC OS Open Ltd
+ * Author: Ben Avison <bavison@riscosopen.org>
+ *
+ * This file is part of FFmpeg.
+ *
+ * FFmpeg is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * FFmpeg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with FFmpeg; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#include "libavutil/arm/asm.S"
+
+CONTEXT .req    a1
+ORIGOUT .req    a2
+IN      .req    a3
+OUT     .req    v1
+REVTAB  .req    v2
+TCOS    .req    v3
+TSIN    .req    v4
+OLDFPSCR .req   v5
+J0      .req    a2
+J1      .req    a4
+J2      .req    ip
+J3      .req    lr
+REVTAB_HI .req  v5
+IN_HI   .req    v6
+OUT_HI  .req    v6
+TCOS_HI .req    sl
+TSIN_HI .req    fp
+
+.macro prerotation_innerloop
+ .set trig_lo, k
+ .set trig_hi, n4 - k - 2
+ .set in_lo, trig_lo * 2
+ .set in_hi, trig_hi * 2
+        vldr    d8, [TCOS, #trig_lo*4]          @ s16,s17
+        vldr    d9, [TCOS, #trig_hi*4]          @ s18,s19
+        vldr    s0, [IN, #in_hi*4 + 12]
+        vldr    s1, [IN, #in_hi*4 + 4]
+        vldr    s2, [IN, #in_lo*4 + 12]
+        vldr    s3, [IN, #in_lo*4 + 4]
+        vmul.f  s8, s0, s16                     @ vector operation
+        vldr    d10, [TSIN, #trig_lo*4]         @ s20,s21
+        vldr    d11, [TSIN, #trig_hi*4]         @ s22,s23
+        vldr    s4, [IN, #in_lo*4]
+        vldr    s5, [IN, #in_lo*4 + 8]
+        vldr    s6, [IN, #in_hi*4]
+        vldr    s7, [IN, #in_hi*4 + 8]
+        ldr     J0, [REVTAB, #trig_lo*2]
+        vmul.f  s12, s0, s20                    @ vector operation
+        ldr     J2, [REVTAB, #trig_hi*2]
+        mov     J1, J0, lsr #16
+        and     J0, J0, #255                    @ halfword value will be < n4
+        vmls.f  s8, s4, s20                     @ vector operation
+        mov     J3, J2, lsr #16
+        and     J2, J2, #255                    @ halfword value will be < n4
+        add     J0, OUT, J0, lsl #3
+        vmla.f  s12, s4, s16                    @ vector operation
+        add     J1, OUT, J1, lsl #3
+        add     J2, OUT, J2, lsl #3
+        add     J3, OUT, J3, lsl #3
+        vstr    s8, [J0]
+        vstr    s9, [J1]
+        vstr    s10, [J2]
+        vstr    s11, [J3]
+        vstr    s12, [J0, #4]
+        vstr    s13, [J1, #4]
+        vstr    s14, [J2, #4]
+        vstr    s15, [J3, #4]
+ .set k, k + 2
+.endm
+
+.macro prerotation_innerloop_rolled
+        vldmia  TCOS!, {s16,s17}
+        vldmdb  TCOS_HI!, {s18,s19}
+        vldr    s0, [IN_HI, #-4]
+        vldr    s1, [IN_HI, #-12]
+        vldr    s2, [IN, #12]
+        vldr    s3, [IN, #4]
+        vmul.f  s8, s0, s16                     @ vector operation
+        vldmia  TSIN!, {s20,s21}
+        vldmdb  TSIN_HI!, {s22,s23}
+        vldr    s4, [IN]
+        vldr    s5, [IN, #8]
+        vldr    s6, [IN_HI, #-16]
+        vldr    s7, [IN_HI, #-8]
+        vmul.f  s12, s0, s20                    @ vector operation
+        add     IN, IN, #16
+        sub     IN_HI, IN_HI, #16
+        ldrh    J0, [REVTAB], #2
+        ldrh    J1, [REVTAB], #2
+        vmls.f  s8, s4, s20                     @ vector operation
+        ldrh    J3, [REVTAB_HI, #-2]!
+        ldrh    J2, [REVTAB_HI, #-2]!
+        add     J0, OUT, J0, lsl #3
+        vmla.f  s12, s4, s16                    @ vector operation
+        add     J1, OUT, J1, lsl #3
+        add     J2, OUT, J2, lsl #3
+        add     J3, OUT, J3, lsl #3
+        vstr    s8, [J0]
+        vstr    s9, [J1]
+        vstr    s10, [J2]
+        vstr    s11, [J3]
+        vstr    s12, [J0, #4]
+        vstr    s13, [J1, #4]
+        vstr    s14, [J2, #4]
+        vstr    s15, [J3, #4]
+.endm
+
+.macro postrotation_innerloop tail, head
+ .set trig_lo_head, n8 - k - 2
+ .set trig_hi_head, n8 + k
+ .set out_lo_head, trig_lo_head * 2
+ .set out_hi_head, trig_hi_head * 2
+ .set trig_lo_tail, n8 - (k - 2) - 2
+ .set trig_hi_tail, n8 + (k - 2)
+ .set out_lo_tail, trig_lo_tail * 2
+ .set out_hi_tail, trig_hi_tail * 2
+ .if (k & 2) == 0
+  TCOS_D0_HEAD .req d10 @ s20,s21
+  TCOS_D1_HEAD .req d11 @ s22,s23
+  TCOS_S0_TAIL .req s24
+ .else
+  TCOS_D0_HEAD .req d12 @ s24,s25
+  TCOS_D1_HEAD .req d13 @ s26,s27
+  TCOS_S0_TAIL .req s20
+ .endif
+ .ifnc "\tail",""
+        vmls.f  s8, s0, TCOS_S0_TAIL        @ vector operation
+ .endif
+ .ifnc "\head",""
+        vldr    d8, [TSIN, #trig_lo_head*4] @ s16,s17
+        vldr    d9, [TSIN, #trig_hi_head*4] @ s18,s19
+        vldr    TCOS_D0_HEAD, [TCOS, #trig_lo_head*4]
+ .endif
+ .ifnc "\tail",""
+        vmla.f  s12, s4, TCOS_S0_TAIL       @ vector operation
+ .endif
+ .ifnc "\head",""
+        vldr    s0, [OUT, #out_lo_head*4]
+        vldr    s1, [OUT, #out_lo_head*4 + 8]
+        vldr    s2, [OUT, #out_hi_head*4]
+        vldr    s3, [OUT, #out_hi_head*4 + 8]
+        vldr    s4, [OUT, #out_lo_head*4 + 4]
+        vldr    s5, [OUT, #out_lo_head*4 + 12]
+        vldr    s6, [OUT, #out_hi_head*4 + 4]
+        vldr    s7, [OUT, #out_hi_head*4 + 12]
+ .endif
+ .ifnc "\tail",""
+        vstr    s8, [OUT, #out_lo_tail*4]
+        vstr    s9, [OUT, #out_lo_tail*4 + 8]
+        vstr    s10, [OUT, #out_hi_tail*4]
+        vstr    s11, [OUT, #out_hi_tail*4 + 8]
+ .endif
+ .ifnc "\head",""
+        vmul.f  s8, s4, s16                 @ vector operation
+ .endif
+ .ifnc "\tail",""
+        vstr    s12, [OUT, #out_hi_tail*4 + 12]
+        vstr    s13, [OUT, #out_hi_tail*4 + 4]
+        vstr    s14, [OUT, #out_lo_tail*4 + 12]
+        vstr    s15, [OUT, #out_lo_tail*4 + 4]
+ .endif
+ .ifnc "\head",""
+        vmul.f  s12, s0, s16                @ vector operation
+        vldr    TCOS_D1_HEAD, [TCOS, #trig_hi_head*4]
+ .endif
+ .unreq TCOS_D0_HEAD
+ .unreq TCOS_D1_HEAD
+ .unreq TCOS_S0_TAIL
+ .ifnc "\head",""
+  .set k, k + 2
+ .endif
+.endm
+
+.macro postrotation_innerloop_rolled tail, head, tcos_s0_head, tcos_s1_head, tcos_s2_head, tcos_s3_head, tcos_s0_tail, out_offset_head, out_offset_tail
+ .ifnc "\tail",""
+        vmls.f  s8, s0, \tcos_s0_tail       @ vector operation
+ .endif
+ .ifnc "\head",""
+        vldmia  TSIN!, {s16,s17}
+        vldmdb  TSIN_HI!, {s18,s19}
+        vldmia  TCOS!, {\tcos_s0_head,\tcos_s1_head}
+ .endif
+ .ifnc "\tail",""
+        vmla.f  s12, s4, \tcos_s0_tail      @ vector operation
+ .endif
+ .ifnc "\head",""
+        vldr    s0, [OUT, #+\out_offset_head+0]
+        vldr    s1, [OUT, #+\out_offset_head+8]
+        vldr    s2, [OUT_HI, #-\out_offset_head-16]
+        vldr    s3, [OUT_HI, #-\out_offset_head-8]
+        vldr    s4, [OUT, #+\out_offset_head+4]
+        vldr    s5, [OUT, #+\out_offset_head+12]
+        vldr    s6, [OUT_HI, #-\out_offset_head-12]
+        vldr    s7, [OUT_HI, #-\out_offset_head-4]
+ .endif
+ .ifnc "\tail",""
+        vstr    s8, [OUT, #+\out_offset_tail+0]
+        vstr    s9, [OUT, #+\out_offset_tail+8]
+        vstr    s10, [OUT_HI, #-\out_offset_tail-16]
+        vstr    s11, [OUT_HI, #-\out_offset_tail-8]
+ .endif
+ .ifnc "\head",""
+        vmul.f  s8, s4, s16                 @ vector operation
+ .endif
+ .ifnc "\tail",""
+        vstr    s12, [OUT_HI, #-\out_offset_tail-4]
+        vstr    s13, [OUT_HI, #-\out_offset_tail-12]
+        vstr    s14, [OUT, #+\out_offset_tail+12]
+        vstr    s15, [OUT, #+\out_offset_tail+4]
+ .endif
+ .ifnc "\head",""
+        vmul.f  s12, s0, s16                @ vector operation
+        vldmdb  TCOS_HI!, {\tcos_s2_head,\tcos_s3_head}
+ .endif
+.endm
+
+
+/* void ff_imdct_half_vfp(FFTContext *s,
+ *                        FFTSample *output,
+ *                        const FFTSample *input)
+ */
+function ff_imdct_half_vfp, export=1
+        ldr     ip, [CONTEXT, #5*4]         @ mdct_bits
+        teq     ip, #6
+        bne     10f
+
+ .set n, 1<<6
+ .set n2, n/2
+ .set n4, n/4
+ .set n8, n/8
+
+        push    {v1-v5,lr}
+        vpush   {s16-s27}
+        fmrx    OLDFPSCR, FPSCR
+        ldr     lr, =0x03030000             @ RunFast mode, short vectors of length 4, stride 1
+        fmxr    FPSCR, lr
+        mov     OUT, ORIGOUT
+        ldr     REVTAB, [CONTEXT, #2*4]
+        ldr     TCOS, [CONTEXT, #6*4]
+        ldr     TSIN, [CONTEXT, #7*4]
+
+ .set k, 0
+ .rept n8/2
+        prerotation_innerloop
+ .endr
+
+        fmxr    FPSCR, OLDFPSCR
+        mov     a1, OUT
+        bl      X(ff_fft16_vfp)
+        ldr     lr, =0x03030000             @ RunFast mode, short vectors of length 4, stride 1
+        fmxr    FPSCR, lr
+
+ .set k, 0
+        postrotation_innerloop , head
+ .rept n8/2 - 1
+        postrotation_innerloop tail, head
+ .endr
+        postrotation_innerloop tail
+
+        fmxr    FPSCR, OLDFPSCR
+        vpop    {s16-s27}
+        pop     {v1-v5,pc}
+
+10:
+        push    {v1-v6,sl,fp,lr}
+        vpush   {s16-s27}
+        fmrx    OLDFPSCR, FPSCR
+        ldr     lr, =0x03030000             @ RunFast mode, short vectors of length 4, stride 1
+        fmxr    FPSCR, lr
+        mov     lr, #1
+        mov     OUT, ORIGOUT
+        ldr     REVTAB, [CONTEXT, #2*4]
+        ldr     TCOS, [CONTEXT, #6*4]
+        ldr     TSIN, [CONTEXT, #7*4]
+        mov     lr, lr, lsl ip
+
+        push    {CONTEXT,OLDFPSCR}
+        add     IN_HI, IN, lr, lsl #1
+        add     REVTAB_HI, REVTAB, lr, lsr #1
+        add     TCOS_HI, TCOS, lr
+        add     TSIN_HI, TSIN, lr
+0:      prerotation_innerloop_rolled
+        teq     IN, IN_HI
+        bne     0b
+        ldmia   sp, {CONTEXT,OLDFPSCR}
+
+        mov     ORIGOUT, OUT
+        fmxr    FPSCR, OLDFPSCR
+        ldr     ip, [CONTEXT, #9*4]
+        blx     ip                          @ s->fft_calc(s, output)
+
+        pop     {CONTEXT,OLDFPSCR}
+        ldr     lr, =0x03030000             @ RunFast mode, short vectors of length 4, stride 1
+        ldr     ip, [CONTEXT, #5*4]         @ mdct_bits
+        fmxr    FPSCR, lr
+        mov     lr, #1
+        mov     lr, lr, lsl ip
+        sub     TCOS, TCOS, lr, lsr #1
+        sub     TSIN, TSIN, lr, lsr #1
+        add     OUT_HI, OUT, lr, lsl #1
+        add     TCOS_HI, TCOS, lr
+        add     TSIN_HI, TSIN, lr
+        postrotation_innerloop_rolled , head, s20, s21, s22, s23,, 0
+        b       1f
+0:      add     OUT, OUT, #32
+        sub     OUT_HI, OUT_HI, #32
+        postrotation_innerloop_rolled tail, head, s20, s21, s22, s23, s24, 0, -16
+1:      postrotation_innerloop_rolled tail, head, s24, s25, s26, s27, s20, 16, 0
+        teq     TSIN, TSIN_HI
+        bne     0b
+        postrotation_innerloop_rolled tail,,,,,, s24,, 16
+
+        fmxr    FPSCR, OLDFPSCR
+        vpop    {s16-s27}
+        pop     {v1-v6,sl,fp,pc}
+endfunc
+
+        .unreq  CONTEXT
+        .unreq  ORIGOUT
+        .unreq  IN
+        .unreq  OUT
+        .unreq  REVTAB
+        .unreq  TCOS
+        .unreq  TSIN
+        .unreq  OLDFPSCR
+        .unreq  J0
+        .unreq  J1
+        .unreq  J2
+        .unreq  J3
+        .unreq  REVTAB_HI
+        .unreq  IN_HI
+        .unreq  OUT_HI
+        .unreq  TCOS_HI
+        .unreq  TSIN_HI


### PR DESCRIPTION
The following series of patches fix cross-compilation linking errors
in the openHEVC code for ARM targets. The patches aim at resolving
undefined references during linking while generating hevc_sdl2 execu-
table which links to libLibOpenHevcWrapper.so library as a result of
missing function definations from ffmpeg libavcodec. The corresponding
files have been merged into existing code to resolve linking time
dependencies.

I request the maintainers to please check the patch and verify that it
doesn't breaks any existing functionality or causes build instability.

Nitin Chaudhary (1):
  [openHEVC] ARM Neon/VFP Compilation Error fix, ffmpeg change merge

 CMakeLists.txt                      |   4 +
 libavcodec/arm/fft_vfp.S            | 530 ++++++++++++++++++++++++++++++++++++
 libavcodec/arm/hpeldsp_armv6.S      | 261 ++++++++++++++++++
 libavcodec/arm/hpeldsp_init_armv6.c |  67 +++++
 libavcodec/arm/mdct_vfp.S           | 347 +++++++++++++++++++++++
 5 files changed, 1209 insertions(+)
 create mode 100644 libavcodec/arm/fft_vfp.S
 create mode 100644 libavcodec/arm/hpeldsp_armv6.S
 create mode 100644 libavcodec/arm/hpeldsp_init_armv6.c
 create mode 100644 libavcodec/arm/mdct_vfp.S
## 

2.7.4

```
Adding files from the latest ffmpeg source tree to resolve the
linker dependecies while generating final executables with VFP
and ARM Neon Support during CROSS COMPILING for ARM using Linaro's
GCC arm-linux-gnueabihf toolchain on x86 Machine
```

Signed-off-by: Nitin Chaudhary Nitin.Chaudhary@zii.aero
