### PR TITLE
EHN: Visual studio 2015 build error fixing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,14 +68,14 @@ if("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "armv7l")
 	)
 endif()
 
-if(WIN32)
-    add_definitions(
-        -Dsnprintf=avpriv_snprintf
-        -Dvsnprintf=avpriv_vsnprintf
-        -Dinline=__inline
-        -Drestrict=__restrict
-    )
-endif()
+#if(WIN32)
+    #add_definitions(
+        #-Dsnprintf=avpriv_snprintf
+        #-Dvsnprintf=avpriv_vsnprintf
+        #-Dinline=__inline
+        #-Drestrict=__restrict
+    #)
+#endif()
 
 #define asm sources
 if(NOT ("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "armv7l") )

--- a/libavcodec/frame_thread_encoder.h
+++ b/libavcodec/frame_thread_encoder.h
@@ -20,7 +20,7 @@
 
 #include "avcodec.h"
 
-int ff_frame_thread_encoder_init(AVCodecContext *avctx, AVDictionary *options);
-void ff_frame_thread_encoder_free(AVCodecContext *avctx);
-int ff_thread_video_encode_frame(AVCodecContext *avctx, AVPacket *pkt, const AVFrame *frame, int *got_packet_ptr);
+int ff_frame_thread_encoder_init(AVCodecContext *avctx, AVDictionary *options) {};
+void ff_frame_thread_encoder_free(AVCodecContext *avctx) {};
+int ff_thread_video_encode_frame(AVCodecContext *avctx, AVPacket *pkt, const AVFrame *frame, int *got_packet_ptr) {};
 

--- a/libavcodec/hevcdsp.c
+++ b/libavcodec/hevcdsp.c
@@ -1326,3 +1326,5 @@ int i = 0;
     if (ARCH_X86) ff_hevcdsp_init_x86(hevcdsp, bit_depth);
     if (ARCH_ARM) ff_hevcdsp_init_arm(hevcdsp, bit_depth);
 }
+
+void ff_hevcdsp_init_arm(HEVCDSPContext *c, const int bit_depth) {};

--- a/libavcodec/videodsp.c
+++ b/libavcodec/videodsp.c
@@ -57,3 +57,9 @@ av_cold void ff_videodsp_init(VideoDSPContext *ctx, int bpc)
     if (ARCH_X86)
         ff_videodsp_init_x86(ctx, bpc);
 }
+
+
+void ff_videodsp_init_aarch64(VideoDSPContext *ctx, int bpc) {};
+void ff_videodsp_init_arm(VideoDSPContext *ctx, int bpc) {};
+void ff_videodsp_init_ppc(VideoDSPContext *ctx, int bpc) {};
+void ff_videodsp_init_x86(VideoDSPContext *ctx, int bpc) {};

--- a/libavcodec/x86/hevc_sao_sse.c
+++ b/libavcodec/x86/hevc_sao_sse.c
@@ -335,7 +335,7 @@ static av_always_inline void ff_hevc_sao_edge_filter_ ## D ##_sse(             \
 }
 
 //SAO_EDGE_FILTER( 8)
-static __attribute__((always_inline)) inline void ff_hevc_sao_edge_filter_8_sse(
+static av_always_inline void ff_hevc_sao_edge_filter_8_sse(
                                                                                 uint8_t *_dst, uint8_t *_src,
                                                                                 ptrdiff_t _stride_dst, ptrdiff_t _stride_src,
                                                                                 struct SAOParams *sao,

--- a/libavutil/x86/cpu.c
+++ b/libavutil/x86/cpu.c
@@ -216,3 +216,8 @@ int ff_get_cpu_flags_x86(void)
 
     return rval;
 }
+
+
+int ff_get_cpu_flags_aarch64(void) {};
+int ff_get_cpu_flags_arm(void) {};
+int ff_get_cpu_flags_ppc(void) {};


### PR DESCRIPTION
1. snprintf and vsnprinft definition removed from cmake file. 2.
use av_always_inline, instead of attribute(always_inline) inline.
3. Functions that have declaration but without definition are filled with
empty implemenation now.