### PR TITLE
unix: portable way to combine multiple .a into one

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,20 +154,18 @@ openhevc-$(OHCONFIG_OHSTATIC): openhevc-static
 
 openhevc-shared: libopenhevc/$(SLIBPREF)openhevc$(BUILDSUF)$(SLIBSUF) libopenhevc/libopenhevc.pc
 
-openhevc-static: libopenhevc/$(LIBPREF)openhevc$(BUILDSUF)$(LIBSUF) libavcodec/$(LIBPREF)avcodec$(BUILDSUF)$(LIBSUF) libavutil/$(LIBPREF)avutil$(BUILDSUF)$(LIBSUF)
-	$(Q)mkdir -p tmp && cp $^ tmp/
-	$(Q)cd tmp &&  $(UNAR) -x $(LIBPREF)openhevc$(BUILDSUF)$(LIBSUF)
-	$(RM) $(LIBPREF)openhevc$(BUILDSUF)$(LIBSUF)
-	$(Q)cd tmp &&  $(UNAR) -x $(LIBPREF)avcodec$(BUILDSUF)$(LIBSUF)
-	$(RM) $(LIBPREF)avcodec$(BUILDSUF)$(LIBSUF)
-	$(Q)cd tmp &&  $(UNAR) -x $(LIBPREF)avutil$(BUILDSUF)$(LIBSUF)
-	$(RM) $(LIBPREF)avutil$(BUILDSUF)$(LIBSUF)
-	$(AR) $(ARFLAGS) tmp/$(LIBPREF)openhevc$(BUILDSUF)$(LIBSUF) tmp/*.o
-	$(Q)cp -f tmp/$(LIBPREF)openhevc$(BUILDSUF)$(LIBSUF) libopenhevc/
-	$(RM) -r tmp
+
+openhevc-static-clean:
+	$(RM) -f libopenhevc/$(LIBPREF)openhevc$(BUILDSUF)$(LIBSUF)
+	$(RM) -f libavcodec/$(LIBPREF)avcodec$(BUILDSUF)$(LIBSUF)
+	$(RM) -f libavutil/$(LIBPREF)avutil$(BUILDSUF)$(LIBSUF)
+
+openhevc-static: openhevc-static-clean libopenhevc/$(LIBPREF)openhevc$(BUILDSUF)$(LIBSUF) libavcodec/$(LIBPREF)avcodec$(BUILDSUF)$(LIBSUF) libavutil/$(LIBPREF)avutil$(BUILDSUF)$(LIBSUF)
+	$(AR) $(ARFLAGS) libopenhevc/$(LIBPREF)openhevc$(BUILDSUF)$(LIBSUF) $(OBJS-libopenhevc/$(LIBPREF)openhevc$(BUILDSUF)$(LIBSUF)) $(OBJS-libavcodec/$(LIBPREF)avcodec$(BUILDSUF)$(LIBSUF)) $(OBJS-libavutil/$(LIBPREF)avutil$(BUILDSUF)$(LIBSUF))
 
 openhevc-static-win: libopenhevc/$(LIBPREF)openhevc$(BUILDSUF)$(LIBSUF) libavcodec/$(LIBPREF)avcodec$(BUILDSUF)$(LIBSUF) libavutil/$(LIBPREF)avutil$(BUILDSUF)$(LIBSUF)
 	$(AR) /OUT:libopenhevc/$(LIBPREF)openhevc$(BUILDSUF).lib libopenhevc/$(LIBPREF)openhevc$(BUILDSUF)$(LIBSUF) libavcodec/$(LIBPREF)avcodec$(BUILDSUF)$(LIBSUF) libavutil/$(LIBPREF)avutil$(BUILDSUF)$(LIBSUF)
+
 
 libavutil/ffversion.h .version:
 	$(M)$(VERSION_SH) $(SRC_PATH) libavutil/ffversion.h $(EXTRA_VERSION)

--- a/ffbuild/library.mak
+++ b/ffbuild/library.mak
@@ -17,6 +17,7 @@ $(LIBOBJS) $(LIBOBJS:.o=.s) $(LIBOBJS:.o=.i):   CPPFLAGS += -DHAVE_AV_CONFIG_H
 #$(TESTOBJS) $(TESTOBJS:.o=.i): CFLAGS += -Umain
 
 $(SUBDIR)$(LIBNAME): $(OBJS)
+	$(eval OBJS-$@ := $^)
 	$(RM) $@
 	$(AR) $(ARFLAGS) $(AR_O) $^
 	$(RANLIB) $@


### PR DESCRIPTION
Hi, 

This time I'm trying to build openhevc statically on both linux and osx and I came across an annoying issue. My solution may not be the best one, if someone has a better idea I'll take it. 

**The problem:** to build a static lib, we first build `libavutil.a` `libavcodec.a` `libopenhevc.a` (with only `openhevc.o` in it), and then combine the 3 to have a proper `libopenhevc.a` containing all symbols. 

The current way of doing the combining is to extract all the contents of the .a libs with `ar -x` and then repackage all the extracted .o files into `libopenhevc.a`. 

This approach has two problems: 
 1. _if different libs have files of the same name they'll be overwritten when extracting_
 2. _if a lib have multiple files of the same name in sub-directories, ar -x will only extract one of them_

1 is easily fixable (just extract into different directories for example), but 2. is more tricky. 

For example, `libavcodec` has `simple_idct.c` and `x86/simple_idct.c`. When creating `libavcodec.a`, ar will create two sections called `simple_idct.o`. When extracting (`ar -x libavcodec.a`) it will only extract one `simple_idct.o` containing the symbols of one the source files. 

**Solution 1**: To get around that, GNU ar can use MRI scripts, for example : 

```
$ cat lib.mri
create libopenhevc.a
addlib libopenhevc/libopenhevc.a
addlib libavcodec/libavcodec.a
addlib libavutil/libavutil.a
save
end
$ ar -M < lib.mri
```

This will generate a proper library, **except**.. that this doesn't work on OSX (which has BSD ar instead of GNU ar). Great.


**Solution 2**: The only way I've found to do this that work on both linux and osx, is to save the list of .o files when creating a library so that we can do `ar <big list of .o files> libopenhevc.a` to build the static lib without having to extract from the intermediary libs.

This may not be the prettiest solution but it seems to work. 

