### PR TITLE
declare roundHP static to avoid Wmissing-prototypes

### DIFF
--- a/libavcodec/hevcdec.c
+++ b/libavcodec/hevcdec.c
@@ -546,7 +546,7 @@ static int getBitDepth(HEVCContext *s, enum ChannelType channel, int layerId)
   return retVal;
 }
 
-int roundHP(double t) {
+static int roundHP(double t) {
     return (int)(t + (t >= 0 ? 0.5 : -0.5));
 }
 


### PR DESCRIPTION
Hi, 

a recent change lead to an error in our build on osx/linux:

```
libavcodec/hevcdec.c:549:5: error: no previous prototype for ‘roundHP’ [-Werror=missing-prototypes]
 int roundHP(double t) {
```

as this links recommends: https://icecube.wisc.edu/~dglo/gcc-warnings.html

> 
> no previous prototype for `foo'
>     This means that GCC found a global function definition without seeing a prototype for the function.
> 
>     If a function is used in more than one file, there should be a prototype for it in a header file somewhere. This keeps functions and their uses from getting out of sync
> 
>     If the function is only used in this file, make it static to
> 
>         guarantee that it'll never be used outside this file
>         document that it's a local function 

I made it static to fix the issue