### PR TITLE
SHVC decoding: fix VPS rep_format values inference

### DIFF
--- a/libavcodec/hevc_ps.c
+++ b/libavcodec/hevc_ps.c
@@ -1268,6 +1268,9 @@ static int parse_vps_extension (GetBitContext *gb, AVCodecContext *avctx, HEVCVP
     vps_ext->vps_num_rep_formats_minus1 = vps_num_rep_formats_minus1;
 
     for( i = 0; i  <=  vps_ext->vps_num_rep_formats_minus1; i++ ){
+        if(i > 0) {
+            vps_ext->rep_format[i] = vps_ext->rep_format[i-1];
+        }
         parse_rep_format(&vps_ext->rep_format[i], gb);
     }
 


### PR DESCRIPTION
Infer the values of bit_depth_vps_luma_minus8 and
bit_depth_vps_chroma_minus8 from the previous rep_format
(as in spec, see F.7.4.3.1.2 Representation format semantics).