### PR TITLE
Fix out-of-tree execution of ./configure

### DIFF
--- a/configure
+++ b/configure
@@ -5849,6 +5849,7 @@ print_config CONFIG_ "$config_files" $CONFIG_LIST       \
 
 print_config OHCONFIG_ "$config_files" $OPENHEVC_COMPONENTS
 
+mkdir -p libopenhevc
 echo > "libopenhevc/ohconfig.h"
 print_config OHCONFIG_ "libopenhevc/ohconfig.h" $OPENHEVC_COMPONENTS
 


### PR DESCRIPTION
Now we can successfully do:
$ mkdir myBuildDir
$ cd myBuildDir
$ ../configure
$ make openhevc

However, ohplay still needs fixing and can't be build this way at the
moment.