### PR TITLE
Fix compilation if sys/sysctl.h is not present

### DIFF
--- a/libavutil/cpu.c
+++ b/libavutil/cpu.c
@@ -39,7 +39,10 @@
 #include <sys/param.h>
 #endif
 #include <sys/types.h>
+
+#if __has_include(<sys/sysctl.h>)
 #include <sys/sysctl.h>
+#endif
 #endif
 #if HAVE_UNISTD_H
 #include <unistd.h>


### PR DESCRIPTION
Glibc 2.32 removes sys/sysctl.h. This commit fixes the compilation with newer versions of Glibc by checking for sys/sysctl.h with has_include.